### PR TITLE
Second batch of pre-1.2 fixes

### DIFF
--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
@@ -150,7 +150,7 @@ end
 -- Args:
 --     entity: entity object or UUID string.
 --     outfile: Optional string file name. Ext.IO.SaveFile throws an error if 'outfile' is a full path.
--- If 'outfile' arg is ommitted, then the output files gets an auto-generated name with an index: entity1.txt, entity2.txt...
+-- If 'outfile' arg is omitted, then the output files gets an auto-generated name with an index: entity1.txt, entity2.txt...
 -- The file is created in ...\AppData\Local\Larian Studios\Baldur's Gate 3\Script Extender folder.
 local DumpEntityCounter = 1
 

--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
@@ -118,10 +118,11 @@ function ActorHasPenis(actor)
 end
 
 function AddMainSexSpells(actor)
-    -- Add "Start Sex" and "Sex Options" spells only if actor is PLAYABLE or HUMANOID or FIEND
+    -- Add "Start Sex" and "Sex Options" spells only if actor is PLAYABLE or HUMANOID or FIEND, and is not a child (KID)
     if (ActorIsPlayable(actor)
         or Osi.IsTagged(actor, "HUMANOID_7fbed0d4-cabc-4a9d-804e-12ca6088a0a8") == 1 
         or Osi.IsTagged(actor, "FIEND_44be2f5b-f27e-4665-86f1-49c5bfac54ab") == 1)
+        and Osi.IsTagged(actor, "KID_ee978587-6c68-4186-9bfc-3b3cc719a835") == 0
     then
         TryAddSpell(actor, "StartSexContainer")
         TryAddSpell(actor, "SexOptions")

--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
@@ -146,6 +146,18 @@ local function ResolveEntityArg(entityArg)
     return entityArg
 end
 
+-- Dump an entity to a text file.
+-- Args:
+--     entity: entity object or UUID string.
+--     outfile: string file name. Ext.IO.SaveFile throws an error if 'outfile' is a full path.
+-- The file is created in ...\AppData\Local\Larian Studios\Baldur's Gate 3\Script Extender folder.
+function DumpEntity(entity, outfile)
+    entity = ResolveEntityArg(entity)
+    if entity then
+        Ext.IO.SaveFile(outfile, Ext.DumpExport(entity:GetAllComponents()))
+    end
+end
+
 -- Get the value of a sub-field in entity if the entity has that sub-field.
 -- Args:
 --     entity: entity object or UUID string.

--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/AnimationFramework.lua
@@ -149,11 +149,18 @@ end
 -- Dump an entity to a text file.
 -- Args:
 --     entity: entity object or UUID string.
---     outfile: string file name. Ext.IO.SaveFile throws an error if 'outfile' is a full path.
+--     outfile: Optional string file name. Ext.IO.SaveFile throws an error if 'outfile' is a full path.
+-- If 'outfile' arg is ommitted, then the output files gets an auto-generated name with an index: entity1.txt, entity2.txt...
 -- The file is created in ...\AppData\Local\Larian Studios\Baldur's Gate 3\Script Extender folder.
+local DumpEntityCounter = 1
+
 function DumpEntity(entity, outfile)
     entity = ResolveEntityArg(entity)
     if entity then
+        if not outfile then
+            outfile = "entity" .. DumpEntityCounter .. ".txt"
+            DumpEntityCounter = DumpEntityCounter + 1
+        end
         Ext.IO.SaveFile(outfile, Ext.DumpExport(entity:GetAllComponents()))
     end
 end

--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/SoloAnimation.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/SoloAnimation.lua
@@ -29,12 +29,15 @@ function StartSoloAnimation(actor, animProperties)
 
     Osi.ObjectTimerLaunch(actor, "SoloSexSetup", setupDelay)
 
-    TryAddSpell(actor, soloData.AnimContainer)
-    TryAddSpell(actor, "ChangeLocationSolo")
+    -- Add sex control spells to the caster
+    SexActor_InitCasterSexSpells(soloData)
+    SexActor_RegisterCasterSexSpell(soloData, soloData.AnimContainer)
+    SexActor_RegisterCasterSexSpell(soloData, "ChangeLocationSolo")
     if soloData.ActorData.CameraScaleDown then
-        TryAddSpell(actor, "CameraHeight")
+        SexActor_RegisterCasterSexSpell(soloData, "CameraHeight")
     end
-    TryAddSpell(actor, "zzzStopMasturbating")
+    SexActor_RegisterCasterSexSpell(soloData, "zzzStopMasturbating")
+    AddSoloCasterSexSpell(soloData)
 end
 
 function SoloAnimationListeners()
@@ -93,6 +96,11 @@ function SoloAnimationListeners()
             SexActor_TerminateProxyMarker(soloData.ProxyData)
 
             AnimationSolos[actor] = nil
+            return
+        end
+
+        if timer == "SoloAddCasterSexSpell" then
+            AddSoloCasterSexSpell(soloData)
             return
         end
 
@@ -212,4 +220,8 @@ function MoveSoloSceneToLocation(actor, x, y, z)
     if soloData then
         SexActor_MoveSceneToLocation(x, y, z, soloData.ActorData, nil, soloData.AnimationProp)
     end
+end
+
+function AddSoloCasterSexSpell(soloData)
+    SexActor_AddCasterSexSpell(soloData, soloData.ActorData, "SoloAddCasterSexSpell")
 end

--- a/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/_DebugSnippets.lua
+++ b/AnimationFramework/Mods/AnimationFramework/ScriptExtender/Lua/Server/_DebugSnippets.lua
@@ -1,16 +1,5 @@
 
 ----------------------------------------------------------------------------------------------------
--- Dump the entity of object 'uuid' to a text file `outfile`.
--- 'outfile' must be a file name. Ext.IO.SaveFile throws an error if 'outfile' is a full path.
--- The file is created in ...\AppData\Local\Larian Studios\Baldur's Gate 3\Script Extender.
-----------------------------------------------------------------------------------------------------
-
-function DumpEntity(uuid, outfile)
-    Ext.IO.SaveFile(outfile, Ext.DumpExport(Ext.Entity.Get(uuid):GetAllComponents()))
-end
-
-
-----------------------------------------------------------------------------------------------------
 -- Loop through a table of sound resources (TestSounds), playing a new sound each time, with console output.
 ----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
* Fixed the random order of sex session control spells in the hotbar.
* Teleport scene routine got a few (temporary) workarounds to fix the unreliable positioning in paired scenes.
* Added a check for KID (child) tag on adding main sex spells to an actor, just to be safe.
* Cleanup.